### PR TITLE
Avoid collision with other declarations of same resource

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -10,7 +10,7 @@ class nodejs::repo::nodesource::apt {
   include ::apt
 
   if ($ensure != 'absent') {
-    apt::source { 'nodesource':
+    $nodejs_apt_source = {
       include  => {
         'src' => $enable_src,
       },
@@ -23,7 +23,7 @@ class nodejs::repo::nodesource::apt {
       release  => $release,
       repos    => 'main',
     }
-
+    ensure_resource('apt::source', 'nodesource', $nodejs_apt_source)
     Apt::Source['nodesource'] -> Package<| tag == 'nodesource_repo' |>
     Class['Apt::Update'] -> Package<| tag == 'nodesource_repo' |>
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
If two manifests contain the same resource, ensure_resource makes resource not not collide with other resources.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Error while evaluating a Function Call, Duplicate declaration for apt::source
-->
